### PR TITLE
feat: can strip namespaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,6 @@ on:
   push:
 
 jobs:
-  submit-dependencies:
-    uses: tacascer-org/actions-workflows/.github/workflows/submit_dependencies.yml@v0.2.0
-    permissions:
-      contents: write
-
   gradle:
     uses: tacascer-org/actions-workflows/.github/workflows/gradle_build.yml@v0.2.0
     with:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # XML Processor Plugin
 
-[![Gradle Plugin Portal Version](https://img.shields.io/gradle-plugin-portal/v/io.github.tacascer.xml-processor)](https://plugins.gradle.org/plugin/io.github.tacascer.xml-processor)
+[![Gradle Plugin Portal Version](https://img.shields.io/gradle-plugin-portal/v/io.github.tacascer.xml-processor?style=for-the-badge&logo=gradle)](https://plugins.gradle.org/plugin/io.github.tacascer.xml-processor)
 
 ![Build](https://github.com/tacascer-org/xml-processor/actions/workflows/build.yml/badge.svg?branch=main)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=tacascer-org_xml-processor-plugin&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=tacascer-org_xml-processor-plugin)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=tacascer-org_xml-processor-plugin&metric=coverage)](https://sonarcloud.io/summary/new_code?id=tacascer-org_xml-processor-plugin)
 
-This plugin packages the [XML Processor](https://github.com/tacascer-org/xml-processor?tab=readme-ov-file#xml-processor) as a Gradle plugin.
+This plugin packages the [XML Processor](https://github.com/tacascer-org/xml-processor?tab=readme-ov-file#xml-processor)
+as a Gradle plugin.
 
 ## Usage
 
@@ -77,6 +78,43 @@ single schema. Here's how you can do it:
 
 4. The `output.xsd` file will now contain a flattened version of your XML schema.
 
-## Contributing
+## Stripping Namespaces
 
-If you want to contribute to the XML Processor Plugin, please create an issue or open a pull request.
+The `stripNamespaces` input is an optional configuration for the `xmlProcessor` extension.
+
+When set to `true`, the plugin removes all namespaces from the XML schema during the flattening
+process. By default, this value is `false`.
+
+```kotlin
+xmlProcessor {
+    flatten {
+        inputFile.set(file("path/to/your/input.xml"))
+        outputFile.set(file("path/to/your/output.xml"))
+        stripNamespaces.set(true)
+    }
+}
+```
+
+In this example, the `xmlFlatten` task will flatten your XML schema and remove all namespaces.
+
+### Example
+
+Consider the following XML schema:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com">
+    <xs:include schemaLocation="sample_1.xsd"/>
+    <xs:element name="sample" type="xs:string"/>
+</xs:schema>
+```
+
+If you run the `xmlFlatten` task with `stripNamespaces` set to `true`, the output will be:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<schema>
+    <include schemaLocation="sample_1.xsd"/>
+    <element name="sample" type="string"/>
+</schema>
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ val kotestVersion = "5.8.1"
 val jetbrainsAnnotationVersion = "24.1.0"
 val slf4jSimpleVersion = "2.0.13"
 val kotlinLoggingVersion = "6.0.9"
-val xmlProcessorVersion = "0.2.1"
+val xmlProcessorVersion = "0.4.0"
 
 dependencies {
     compileOnly("org.jetbrains:annotations:$jetbrainsAnnotationVersion")
@@ -41,11 +41,14 @@ kotlin {
 testing {
     suites {
         withType<JvmTestSuite> {
-            useJUnitJupiter()
             dependencies {
                 implementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
                 runtimeOnly("org.slf4j:slf4j-simple:$slf4jSimpleVersion")
             }
+        }
+
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter()
         }
 
         val functionalTest by registering(JvmTestSuite::class) {
@@ -58,7 +61,7 @@ testing {
             targets {
                 all {
                     testTask.configure {
-                        shouldRunAfter(tasks.test)
+                        shouldRunAfter(test)
                     }
                 }
             }

--- a/src/main/kotlin/io/github/tacascer/XmlProcessorPlugin.kt
+++ b/src/main/kotlin/io/github/tacascer/XmlProcessorPlugin.kt
@@ -7,12 +7,14 @@ import org.gradle.api.Project
 class XmlProcessorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = project.extensions.create("xmlProcessor", XmlProcessorPluginExtension::class.java)
+        extension.flatten.stripNamespaces.convention(false)
         project.tasks.register("xmlFlatten", XMLFlattenTask::class.java) {
             it.apply {
                 group = "xml"
                 description = "Flatten XML file"
                 inputFile.set(extension.flatten.inputFile)
                 outputFile.set(extension.flatten.outputFile)
+                stripNamespaces.set(extension.flatten.stripNamespaces)
             }
         }
     }

--- a/src/main/kotlin/io/github/tacascer/flatten/FlattenParams.kt
+++ b/src/main/kotlin/io/github/tacascer/flatten/FlattenParams.kt
@@ -1,8 +1,10 @@
 package io.github.tacascer.flatten
 
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 
 interface FlattenParams {
     val inputFile: RegularFileProperty
     val outputFile: RegularFileProperty
+    val stripNamespaces: Property<Boolean>
 }

--- a/src/main/kotlin/io/github/tacascer/flatten/XMLFlattenTask.kt
+++ b/src/main/kotlin/io/github/tacascer/flatten/XMLFlattenTask.kt
@@ -3,6 +3,8 @@ package io.github.tacascer.flatten
 import io.github.tacascer.XmlIncludeFlattener
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -14,10 +16,13 @@ abstract class XMLFlattenTask : DefaultTask() {
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
+    @get:Input
+    abstract val stripNamespaces: Property<Boolean>
+
     @TaskAction
     fun flatten() {
         val file = outputFile.get().asFile
-        val flattener = XmlIncludeFlattener(inputFile.get().asFile.toPath())
+        val flattener = XmlIncludeFlattener(inputFile.get().asFile.toPath(), stripNamespace = stripNamespaces.get())
         file.parentFile.mkdirs()
         flattener.process(file.toPath())
     }

--- a/src/test/kotlin/io/github/tacascer/flatten/XmlFlattenTaskTest.kt
+++ b/src/test/kotlin/io/github/tacascer/flatten/XmlFlattenTaskTest.kt
@@ -43,6 +43,49 @@ class XmlFlattenTaskTest : FunSpec({
             it.apply {
                 inputFile.set(includingFile.toFile())
                 outputFile.set(testOutputFile.toFile())
+                stripNamespaces.set(false)
+            }
+        }
+
+        xmlFlatten.get().flatten()
+
+        testOutputFile.readText().trimIndent() shouldBe expectedText
+    }
+
+    test("XmlFlattenTask should strip namespace from final file if stripNamespaces is true") {
+        val testDir = tempdir()
+        val includingFile = testDir.toPath().resolve("sample.xsd").createFile()
+        val includedFile = testDir.toPath().resolve("sample_1.xsd").createFile()
+        val testOutputFile = testDir.toPath().resolve("output.xsd").createFile()
+        @Language("XML") val includingFileText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.sample.com">
+                <xs:include schemaLocation="${testDir.toPath().resolve("sample_1.xsd").toUri()}"/>
+                <xs:element name="sample" type="xs:string"/>
+            </xs:schema>
+            """.trimIndent()
+        includingFile.writeText(includingFileText)
+        @Language("XML") val includedFileText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+                <xs:element name="sampleOne" type="xs:string"/>
+            </xs:schema>
+            """.trimIndent()
+        includedFile.writeText(includedFileText)
+
+        @Language("XML") val expectedText = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <schema targetNamespace="http://www.sample.com">
+            <element name="sample" type="string" />
+            <element name="sampleOne" type="string" />
+        </schema>
+        """.trimIndent()
+        val project = ProjectBuilder.builder().build()
+        val xmlFlatten = project.tasks.register("xmlFlatten", XMLFlattenTask::class.java) {
+            it.apply {
+                inputFile.set(includingFile.toFile())
+                outputFile.set(testOutputFile.toFile())
+                stripNamespaces.set(true)
             }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature to strip namespaces from XML schemas during flattening.
	- Added a new configuration option to enable or disable the stripping of namespaces in XML processing tasks.

- **Documentation**
	- Updated the plugin description and adjusted the style of the Gradle plugin portal version badge.

- **Tests**
	- Added new test configurations and a specific test to verify the new namespace stripping functionality.

- **Chores**
	- Updated XML processor version to enhance performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->